### PR TITLE
Add open in codepen button so people can test their builds faster.

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -40,8 +40,13 @@ body_id: builder
     <div class="buttons-area">
       <button type="button" class="wt btn dev" id="generate">Generate</button>
       <a class="btn" id="download-btn">Download</a>
+      <button class="wt btn dev cpp" form="codepen_prefill">Open in codepen.io</button>
     </div>
 
+  </form>
+
+  <form action="http://codepen.io/pen/define" method="POST" target="_blank" id="codepen_prefill">
+    <input type="hidden" name="data" value="" id="codepen_data">
   </form>
 
   <div id="source">

--- a/i/css/modernizr-3.0.0-beta.css
+++ b/i/css/modernizr-3.0.0-beta.css
@@ -483,6 +483,10 @@ nav {
 .localstorage.no-touch .btn.dev:before {
   background-position: 0 -300px;
 }
+.localstorage.no-touch .btn.cpp:before {
+  background: url('http://s.cdpn.io/3/cp-arrow-right.svg') 0 50% no-repeat;
+  background-size: 24px auto;
+}
 .localstorage.no-touch .btn:hover:before {
   opacity: .82;
 }

--- a/i/js/builderapp2.js
+++ b/i/js/builderapp2.js
@@ -96,8 +96,29 @@ require(['build', '../lib/build-hash'], function( builder, generateBuildHash ) {
         .css('display', 'inline-block');
 
       updateHash(buildHash);
-
+      buildCodepenPrefillValue(fileName, $outBox.text(), buildHash);
     });
+  }
+
+  function buildCodepenPrefillValue(name, source, hash) {
+      var data = {
+        title              : name,
+        description        : "This is generated via modernizr.com/download",
+        html               : "<h1>Modernizr build auto generated</h1><p><a href='http://v3.modernizr.com/download" + hash + "'>Build hash</a></p>",
+        css                : "ul{-webkit-column-count: 3;-moz-column-count: 3;column-count: 3;}li{color:green}",
+        js                 : source
+      };
+      var ul = $('<ul>');
+      var features = hash.slice(2).split('-');
+
+      $.each(features, function(i, feature) {
+        data.css += '.no-' + feature + ' li.'+ feature +'{ color: red; }'
+        ul.append('<li class="'+ feature +'">' + feature + '</li>');
+      });
+
+      data.html += ul[0].outerHTML;
+
+      $('#codepen_data').val(JSON.stringify(data));
   }
 
   // Options are hard-coded for now


### PR DESCRIPTION
Thought this would be cool to have. 

Adds a open in codepen button which posts the generated source so people can play around with their custom builds a lot faster.

![screen shot 2015-03-14 at 7 21 49 pm](https://cloud.githubusercontent.com/assets/143402/6650925/9a8e8a4e-ca7f-11e4-8680-f63f0d432ad2.png)

![screen shot 2015-03-14 at 7 22 33 pm](https://cloud.githubusercontent.com/assets/143402/6650926/9be937f4-ca7f-11e4-90a4-b3087fe4da85.png)

cc @chriscoyier any objections if we do this?
